### PR TITLE
Add pre-upgrade hook for csidriver

### DIFF
--- a/charts/juicefs-csi-driver/templates/csidriver.yaml
+++ b/charts/juicefs-csi-driver/templates/csidriver.yaml
@@ -3,7 +3,7 @@ kind: CSIDriver
 metadata:
   name: csi.juicefs.com
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/resource-policy": keep
 spec:


### PR DESCRIPTION
Use case: we are using this csi chart as one subchart of our own chart, and our own chart has already been deployed in the cluster. So we would like to use `helm upgrade` command to upgrade the deployed chart. However, since the hook is specified to only triggered on `pre-install`, it will not be applied when we run the `upgrade` command. 