### PR TITLE
fix remove csi/reg sock before stop

### DIFF
--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver
 type: application
-version: 0.9.2
+version: 0.9.3
 appVersion: 0.13.2
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/juicedata/juicefs-csi-driver

--- a/charts/juicefs-csi-driver/README.md
+++ b/charts/juicefs-csi-driver/README.md
@@ -1,6 +1,6 @@
 # juicefs-csi-driver
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.2](https://img.shields.io/badge/AppVersion-0.13.2-informational?style=flat-square)
+![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.2](https://img.shields.io/badge/AppVersion-0.13.2-informational?style=flat-square)
 
 A Helm chart for JuiceFS CSI Driver
 

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -89,6 +89,15 @@ spec:
         - mountPath: /root/.juicefs
           mountPropagation: Bidirectional
           name: jfs-root-dir
+        - name: registration-dir
+          mountPath: /registration
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/csi.juicefs.com-reg.sock /csi/csi.sock
       - name: node-driver-registrar
         image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
         args:
@@ -100,13 +109,6 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: {{ .Values.kubeletDir }}/csi-plugins/csi.juicefs.com/csi.sock
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - rm -rf /registration/csi.juicefs.com-reg.sock /csi/csi.sock
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -97,7 +97,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - rm -rf /registration/csi.juicefs.com-reg.sock /csi/csi.sock
+              - rm /registration/csi.juicefs.com-reg.sock /csi/csi.sock
       - name: node-driver-registrar
         image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
         args:


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/311

preStop in csi registration container result in error as follows and add preStop in juicefs plugin:

```
29m         Warning   FailedPreStopHook   pod/juicefs-csi-node-nc4xr                                           Exec lifecycle hook ([/bin/sh -c rm -rf $(DRIVER_REG_SOCK_PATH)]) for Container "node-driver-registrar" in Pod "juicefs-csi-node-nc4xr_kube-system(8a273b9d-2caf-4724-ae1c-3f47db66f640)" failed - error: command '/bin/sh -c rm -rf $(DRIVER_REG_SOCK_PATH)' exited with 126: , message: "OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: exec: \"/bin/sh\": stat /bin/sh: no such file or directory: unknown\r\n"
```