### PR TITLE
fix StorageClass.parameters mountPod limit and request

### DIFF
--- a/charts/juicefs-csi-driver/templates/storageclass.yaml
+++ b/charts/juicefs-csi-driver/templates/storageclass.yaml
@@ -66,18 +66,18 @@ parameters:
   {{- with $sc.mountPod }}
   {{- if .resources.limits }}
   {{- if .resources.limits.cpu }}
-  juicefs/mount-cpu-limit: {{ .resources.limits.cpu }}
+  juicefs/mount-cpu-limit: {{ .resources.limits.cpu | quote }}
   {{- end }}
   {{- if .resources.limits.memory }}
-  juicefs/mount-memory-limit: {{ .resources.limits.memory }}
+  juicefs/mount-memory-limit: {{ .resources.limits.memory | quote }}
   {{- end }}
   {{- end }}
   {{- if .resources.requests }}
   {{- if .resources.requests.cpu }}
-  juicefs/mount-cpu-request: {{ .resources.requests.cpu }}
+  juicefs/mount-cpu-request: {{ .resources.requests.cpu | quote }}
   {{- end }}
   {{- if .resources.requests.memory }}
-  juicefs/mount-memory-request: {{ .resources.requests.memory }}
+  juicefs/mount-memory-request: {{ .resources.requests.memory | quote }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
fix error 
```
client.go:128: [debug] creating 10 resource(s)
Error: INSTALLATION FAILED: StorageClass in version "v1" cannot be handled as a StorageClass: json: cannot unmarshal number into Go struct field StorageClass.parameters of type string
helm.go:84: [debug] StorageClass in version "v1" cannot be handled as a StorageClass: json: cannot unmarshal number into Go struct field StorageClass.parameters of type string
INSTALLATION FAILED
```