### PR TITLE
Fix failing lint of juicefs-csi-driver

### DIFF
--- a/charts/juicefs-csi-driver/templates/serviceaccount.yaml
+++ b/charts/juicefs-csi-driver/templates/serviceaccount.yaml
@@ -136,7 +136,7 @@ subjects:
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}
 ---
-{{- if .Values.serviceAccount.node.create -}}
+{{- if .Values.serviceAccount.node.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
`helm lint` of the `juicefs-csi-driver` fails due to a missing whitespace which passes a helm template or install but fails lint. The helm guys [know this can happen](https://github.com/helm/helm/issues/10149). Anyway, this is a problem for someone who include this chart as a subchart and then lint fails on the parent chart.

The `juicefs-s3-gateway` is okay.

The failure looks like:
```
helm lint juicefs-csi-driver
==> Linting juicefs-csi-driver
[ERROR] templates/serviceaccount.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1

Error: 1 chart(s) linted, 1 chart(s) failed
```

You might consider running `helm lint` in your workflow job.