### PR TITLE
fix: affinity config

### DIFF
--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -116,7 +116,7 @@ spec:
       serviceAccount: {{ include "juicefs-csi.controller.serviceAccountName" . }}
       {{- with .Values.controller.affinity }}
       affinity:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -144,7 +144,7 @@ spec:
       priorityClassName: system-node-critical
       {{- with .Values.node.affinity }}
       affinity:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.node.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
I found that there is a problem with the affinity part. When I modify this part, it cannot be run `helm install` on k8s. So, I correct it, please feel free to review it.