### PR TITLE
feat: Add flexible PriorityClass name

### DIFF
--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -179,7 +179,7 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      priorityClassName: system-cluster-critical
+      priorityClassName: {{ .Values.controller.priorityClassName }}
       serviceAccount: {{ include "juicefs-csi.controller.serviceAccountName" . }}
       {{- with .Values.controller.affinity }}
       affinity:

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -166,7 +166,7 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      priorityClassName: system-node-critical
+      priorityClassName: {{ .Values.node.priorityClassName }}
       {{- with .Values.node.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -114,6 +114,8 @@ controller:
   service:
     port: 9909
     type: ClusterIP
+  # -- PriorityClass name for CSI Controller pod
+  priorityClassName: system-cluster-critical
 
 node:
   # -- Default is `true`. CSI Node Service will be deployed in every node.
@@ -141,6 +143,8 @@ node:
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
+  # -- PriorityClass name for CSI Node Service pods
+  priorityClassName: system-node-critical
 
 defaultMountImage:
   # -- Default Mount image for community edition, usually set in juicefs-csi-driver image.


### PR DESCRIPTION
PriorityClass that is currently set as default can cause trouble in managed environments where class modification is limited. This is a solution where operators can choose which class to use for node (DaemonSet) and controller (StatefulSet).