### PR TITLE
Add support for setting `JUICEFS_IMMUTABLE` in the CSI driver

### DIFF
--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -92,6 +92,10 @@ spec:
           value: "Never"
         {{- end }}
         {{- end }}
+        {{- if .Values.immutable }}
+        - name: JUICEFS_IMMUTABLE
+          value: "true"
+        {{- end }}
         {{- if .Values.controller.envs }}
 {{ toYaml .Values.controller.envs | trim | indent 8 }}
         {{- end }}

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -88,6 +88,10 @@ spec:
           value: {{ .Values.defaultMountImage.ee }}
         {{- end }}
         {{- end }}
+        {{- if .Values.immutable }}
+        - name: JUICEFS_IMMUTABLE
+          value: "true"
+        {{- end }}
         {{- if .Values.node.envs }}
 {{ toYaml .Values.node.envs | trim | indent 8 }}
         {{- end }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -53,6 +53,10 @@ jfsMountDir: /var/lib/juicefs/volume
 # -- JuiceFS config directory
 jfsConfigDir: /var/lib/juicefs/config
 
+# Specifies whether JuiceFS is being deployed in an immutable Kubernetes environment.
+# Immutable environments, such as Talos Linux, have read-only paths in the host filesystem.
+immutable: false
+
 dnsPolicy: ClusterFirstWithHostNet
 dnsConfig:
   {}


### PR DESCRIPTION
Introduces control over `JUICEFS_IMMUTABLE` introduced in https://github.com/juicedata/juicefs-csi-driver/pull/680. If enabled, the variable is set for both the controller and node instances. `immutable` defaults to false to maintain the existing behavior by default.