### PR TITLE
feat: Manage annotations for the mount pod

### DIFF
--- a/charts/juicefs-csi-driver/templates/storageclass.yaml
+++ b/charts/juicefs-csi-driver/templates/storageclass.yaml
@@ -95,6 +95,10 @@ parameters:
   {{- if .image }}
   juicefs/mount-image: {{ .image }}
   {{- end }}
+  {{- if .annotations }}
+  juicefs/mount-annotations:
+    {{- toYaml .annotations | nindent 4 }}
+  {{- end }}
   {{- end }}
 provisioner: csi.juicefs.com
 reclaimPolicy: {{ $sc.reclaimPolicy }}

--- a/charts/juicefs-csi-driver/templates/storageclass.yaml
+++ b/charts/juicefs-csi-driver/templates/storageclass.yaml
@@ -96,8 +96,7 @@ parameters:
   juicefs/mount-image: {{ .image }}
   {{- end }}
   {{- if .annotations }}
-  juicefs/mount-annotations:
-    {{- toYaml .annotations | nindent 4 }}
+  juicefs/mount-annotations: {{ toJson .annotations | quote }}
   {{- end }}
   {{- end }}
 provisioner: csi.juicefs.com

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -325,3 +325,5 @@ storageClasses:
         memory: 1Gi
     # Override mount pod image, ref: https://juicefs.com/docs/csi/guide/custom-image
     image: ""
+    # Set annotations for the mount pod
+    annotations: {}


### PR DESCRIPTION
Add annotation management for mount Pod based on available configurations mentioned visible here:

https://github.com/juicedata/juicefs-csi-driver/blob/389a025dccaf777dd996fdb604e636a68b8f1bd5/pkg/config/config.go#L113

This might help include annotation like `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` to enable node termination where Pods do not have `ownerReferences` (meaning, are not created by higher abstraction resource like Deployment for example).

Please confirm CSI driver is able to understand multiple annotations:

https://github.com/juicedata/juicefs-csi-driver/blob/389a025dccaf777dd996fdb604e636a68b8f1bd5/pkg/config/setting_test.go#L356