### PR TITLE
Add extra labels and annotations for csi components pods

### DIFF
--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -19,6 +19,13 @@ spec:
       labels:
         app: juicefs-csi-controller
         {{- include "juicefs-csi.selectorLabels" . | nindent 8 }}
+        {{- if .Values.controller.extraLabels }}
+        {{- toYaml .Values.controller.extraLabels | nindent 8}}
+        {{- end}}
+      {{- with .Values.controller.extraAnnotations }}
+      annotations:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -24,7 +24,7 @@ spec:
         {{- end}}
       {{- with .Values.controller.extraAnnotations }}
       annotations:
-          {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -21,6 +21,13 @@ spec:
       labels:
         app: juicefs-csi-node
         {{- include "juicefs-csi.selectorLabels" . | nindent 8 }}
+        {{- if .Values.node.extraLabels }}
+        {{- toYaml .Values.node.extraLabels | nindent 8}}
+        {{- end}}
+      {{- with .Values.node.extraAnnotations }}
+      annotations:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/juicefs-csi-driver/templates/deployment.yaml
+++ b/charts/juicefs-csi-driver/templates/deployment.yaml
@@ -13,6 +13,13 @@ spec:
     matchLabels:
       app: juicefs-csi-dashboard
       {{- include "juicefs-csi.selectorLabels" . | nindent 6 }}
+      {{- if .Values.dashboard.extraLabels }}
+        {{- toYaml .Values.dashboard.extraLabels | nindent 8}}
+        {{- end}}
+      {{- with .Values.dashboard.extraAnnotations }}
+      annotations:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
   template:
     metadata:
       labels:

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -124,6 +124,10 @@ controller:
       memory: 512Mi
   # Grace period to allow the CSI Controller pod to shutdown before it is killed
   terminationGracePeriodSeconds: 30
+  # Extra customization labels for CSI Controller pod
+  extraLabels: {}
+  # Extra customization annotations for CSI Controller pod
+  extraAnnotations: {}
   # Affinity for CSI Controller pod
   affinity: {}
   # Node selector for CSI Controller pod
@@ -163,6 +167,10 @@ node:
   mountPodNonPreempting: false
   # Grace period to allow the CSI Node Service pods to shutdown before it is killed
   terminationGracePeriodSeconds: 30
+  # Extra customization labels for CSI Node Service pods
+  extraLabels: {}
+  # Extra customization annotations for CSI Node Service pods
+  extraAnnotations: {}
   # Affinity for CSI Node Service pods
   affinity: {}
   # Node selector for CSI Node Service pods, ref: https://juicefs.com/docs/csi/guide/resource-optimization#csi-node-node-selector
@@ -214,6 +222,10 @@ dashboard:
     requests:
       cpu: 100m
       memory: 200Mi
+  # Extra customization labels for dashboard pods
+  extraLabels: {}
+  # Extra customization annotations for dashboard pods
+  extraAnnotations: {}
   affinity: {}
   nodeSelector: {}
   tolerations:


### PR DESCRIPTION
Allow users to customize their CSI component pods' labels and annotations. It's useful in some service discovery scenarios. For example, Prometheus can use pod annotations to discover the scrape targets. 