### PR TITLE
feat: mount fuse volumes into csi-node

### DIFF
--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -154,6 +154,11 @@ spec:
           mountPropagation: Bidirectional
           name: jfs-root-dir
         {{- end }}
+        {{- if and (eq .Values.mountMode "mountpod") (.Values.node.abortFuseConnections) }}
+        - mountPath: /sys/fs/fuse
+          name: fuse
+          mountPropagation: Bidirectional
+        {{- end }}
         lifecycle:
           preStop:
             exec:
@@ -246,5 +251,11 @@ spec:
           path: {{ .Values.jfsConfigDir }}
           type: DirectoryOrCreate
         name: jfs-root-dir
+      {{- end }}
+      {{- if and (eq .Values.mountMode "mountpod") (.Values.node.abortFuseConnections) }}
+      - hostPath:
+          path: /sys/fs/fuse
+          type: Directory
+        name: fuse
       {{- end }}
 {{- end }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -65,13 +65,12 @@ jfsConfigDir: /var/lib/juicefs/config
 immutable: false
 
 dnsPolicy: ClusterFirstWithHostNet
-dnsConfig:
-  {}
-  # Example config which uses the AWS nameservers
-  # dnsPolicy: "None"
-  # dnsConfig:
-  #   nameservers:
-  #     - 169.254.169.253
+dnsConfig: {}
+# Example config which uses the AWS nameservers
+# dnsPolicy: "None"
+# dnsConfig:
+#   nameservers:
+#     - 169.254.169.253
 
 serviceAccount:
   controller:
@@ -132,8 +131,8 @@ controller:
   nodeSelector: {}
   # Tolerations for CSI Controller pod
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
   # CSI Controller service
   service:
     port: 9909
@@ -152,6 +151,8 @@ node:
   # Enable verbose logging
   debug: false
   hostNetwork: false
+  # Enable the node service abort fuse connections when the mountpod stuck in terminating state, only work in mountpod mode
+  abortFuseConnections: false
   resources:
     limits:
       cpu: 1000m
@@ -173,8 +174,8 @@ node:
   nodeSelector: {}
   # Tolerations for CSI Node Service pods
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
   # PriorityClass name for CSI Node Service pods
   priorityClassName: system-node-critical
   # -- Extra envs of CSI Node
@@ -223,8 +224,8 @@ dashboard:
   affinity: {}
   nodeSelector: {}
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
   service:
     port: 8088
     type: ClusterIP
@@ -232,13 +233,13 @@ dashboard:
     enabled: false
     className: "nginx"
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: ""
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
+    - host: ""
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
ref: https://github.com/juicedata/juicefs-csi-driver/pull/907

如 https://github.com/juicedata/juicefs-csi-driver/issues/744 描述。

`/sys/fs/fuse` 可能不存在

挂载 /sys/fs 也许可以，但可能会导致一些意想不到的问题？/cc @davies 

也许提供一个选项来选择挂载与否？/cc @timfeirg 