### PR TITLE
Upgrade default csi sidecar image

### DIFF
--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -170,6 +170,18 @@ spec:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         - --v=5
+        {{- if gt .Values.sidecars.nodeDriverRegistrarImage.tag "v2.4.0" }}
+        - --health-port=9809
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+       {{- end }}
         env:
         - name: ADDRESS
           value: /csi/csi.sock

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -19,20 +19,20 @@ dashboardImage:
 
 sidecars:
   livenessProbeImage:
-    repository: quay.io/k8scsi/livenessprobe
-    tag: "v1.1.0"
+    repository: registry.k8s.io/sig-storage/livenessprobe
+    tag: "v2.11.0"
     pullPolicy: ""
   nodeDriverRegistrarImage:
-    repository: quay.io/k8scsi/csi-node-driver-registrar
-    tag: "v2.1.0"
+    repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    tag: "v2.9.0"
     pullPolicy: ""
   csiProvisionerImage:
-    repository: quay.io/k8scsi/csi-provisioner
-    tag: "v1.6.0"
+    repository: registry.k8s.io/sig-storage/csi-provisioner
+    tag: "v2.2.2"
     pullPolicy: ""
   csiResizerImage:
-    repository: quay.io/k8scsi/csi-resizer
-    tag: "v1.0.1"
+    repository: registry.k8s.io/sig-storage/csi-resizer
+    tag: "v1.9.0"
     pullPolicy: ""
 
 imagePullSecrets: []
@@ -65,13 +65,12 @@ jfsConfigDir: /var/lib/juicefs/config
 immutable: false
 
 dnsPolicy: ClusterFirstWithHostNet
-dnsConfig:
-  {}
-  # Example config which uses the AWS nameservers
-  # dnsPolicy: "None"
-  # dnsConfig:
-  #   nameservers:
-  #     - 169.254.169.253
+dnsConfig: {}
+# Example config which uses the AWS nameservers
+# dnsPolicy: "None"
+# dnsConfig:
+#   nameservers:
+#     - 169.254.169.253
 
 serviceAccount:
   controller:
@@ -132,8 +131,8 @@ controller:
   nodeSelector: {}
   # Tolerations for CSI Controller pod
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
   # CSI Controller service
   service:
     port: 9909
@@ -173,8 +172,8 @@ node:
   nodeSelector: {}
   # Tolerations for CSI Node Service pods
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
   # PriorityClass name for CSI Node Service pods
   priorityClassName: system-node-critical
   # -- Extra envs of CSI Node
@@ -223,8 +222,8 @@ dashboard:
   affinity: {}
   nodeSelector: {}
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
   service:
     port: 8088
     type: ClusterIP
@@ -232,13 +231,13 @@ dashboard:
     enabled: false
     className: "nginx"
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: ""
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
+    - host: ""
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
- Upgrade default csi sidecar image
- [x] livenessprobe `v1.10` => `v2.11.0`
- [x] node-driver-registrar `v2.1.0` => `v2.9.0`
- [x] csi-provisioner `v1.6.0` => `v2.2.2`
- [x] csi-resizer`v1.0.1` => `1.9.0`
  
   Test pass in local/test env, and [full e2e test](https://github.com/juicedata/juicefs-csi-driver/actions/runs/8534006157?pr=923)

- Add liveness probe in `node-driver-registrar` container

   ref: https://github.com/kubernetes-csi/node-driver-registrar/issues/139#issuecomment-1854517937
   
   
 releated issue: https://github.com/juicedata/juicefs-csi-driver/issues/910
 
 after this pr the issue may be resolved
 
 `driver name csi.juicefs.com not found in the list of registered CSI drivers`