### PR TITLE
add release notes with changes for chart release

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -24,3 +24,4 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Name }}-{{ .Version }}"
+          CR_GENERATE_RELEASE_NOTES: true


### PR DESCRIPTION
Thanks for maintaining this chart!

This just updates helm-chart-release.yaml to turn on release notes so that your releases have a whats changed section like this: https://github.com/nextcloud/helm/releases/tag/nextcloud-4.6.8

We have the same thing turned on over at the community run nextcloud chart [here](https://github.com/nextcloud/helm/blob/1ae7421fd91a9e3b30f4f3fa27f60e2481dbbd63/.github/workflows/release.yaml#L43):      
```yaml
CR_GENERATE_RELEASE_NOTES: true
```

When these are turned on, those who use [renovatebot](https://github.com/renovatebot/renovate) to automatically generate PRs for new helm chart releases will get a summary of your releases. As an example, since Argo CD has these turned on, you can see a PR to update the chart version has the release notes here: https://github.com/small-hack/argocd-apps/pull/856

Best regards!