### PR TITLE
Metrics port for daemoset

### DIFF
--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -131,7 +131,7 @@ spec:
         ports:
         - containerPort: {{ .Values.node.livenessProbe.httpGet.port }}
           protocol: TCP
-        - containerPort: 6060
+        - containerPort: 9567
           name: metrics
           protocol: TCP
         securityContext:

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -227,7 +227,10 @@ node:
   # Grace period to allow the CSI Node Service pods to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   labels: {}
+  # example ServiceDiscovery for Prometheus scrape 
   annotations: {}
+  #  prometheus.io/port: "9567"
+  #  prometheus.io/scrape: "true"
   # Affinity for CSI Node Service pods
   affinity: {}
   # Node selector for CSI Node Service pods, ref: https://juicefs.com/docs/csi/guide/resource-optimization#csi-node-node-selector


### PR DESCRIPTION
Metrics port for daemoset. 

When on 

```
mountMode:process 
```

Change metrics port 6060 on 9567  in file charts/juicefs-csi-driver/templates/daemonset.yaml
because port 6060 does not output metrics

add example description charts/juicefs-csi-driver/values.yaml

```
annotations: {}
  #  prometheus.io/port: "9567"
  #  prometheus.io/scrape: "true"
  # Affinity for CSI Node Service pods
```

