### PR TITLE
Support storageclass to use existing secret

### DIFF
--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver
 type: application
-version: 0.21.1
+version: 0.21.2
 appVersion: 0.25.2
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/juicedata/juicefs-csi-driver

--- a/charts/juicefs-csi-driver/templates/storageclass.yaml
+++ b/charts/juicefs-csi-driver/templates/storageclass.yaml
@@ -1,7 +1,7 @@
 {{ $namespace := .Release.Namespace | quote }}
 {{- range $_, $sc := .Values.storageClasses }}
 
-{{- if $sc.enabled }}
+{{- if and $sc.enabled $sc.secretEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -44,7 +44,15 @@ data:
   format-options: {{ .formatOptions | b64enc | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 ---
+{{- if $sc.enabled }}
+
+{{- $secretName := printf "%s-secret" $sc.name -}}
+{{- if not $sc.secretEnabled }}
+{{ $secretName = $sc.secretName | quote }}
+{{- end }}
+
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -61,12 +69,12 @@ mountOptions:
 {{- end }}
 allowVolumeExpansion: {{ $sc.allowVolumeExpansion }}
 parameters:
-  csi.storage.k8s.io/node-publish-secret-name: {{ $sc.name }}-secret
+  csi.storage.k8s.io/node-publish-secret-name: {{ $secretName }}
   csi.storage.k8s.io/node-publish-secret-namespace: {{ $namespace }}
-  csi.storage.k8s.io/provisioner-secret-name: {{ $sc.name }}-secret
+  csi.storage.k8s.io/provisioner-secret-name: {{ $secretName }}
   csi.storage.k8s.io/provisioner-secret-namespace: {{ $namespace }}
   {{- if $sc.allowVolumeExpansion }}
-  csi.storage.k8s.io/controller-expand-secret-name: {{ $sc.name }}-secret
+  csi.storage.k8s.io/controller-expand-secret-name: {{ $secretName }}
   csi.storage.k8s.io/controller-expand-secret-namespace: {{ $namespace }}
   {{- end }}
   {{- if $sc.pathPattern }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -352,6 +352,10 @@ storageClasses:
 - name: "juicefs-sc"
   # Set to true to actually create this StorageClass
   enabled: false
+  # Set secretEnabled to indicate whether you need to create the secret. If False, you can set the existing secret.
+  secretEnabled: true
+  # Must set secretName when secretEnabled is false
+  secretName: juicefs-exist-secret
   # Either Retain or Delete, ref: https://juicefs.com/docs/csi/guide/resource-optimization#reclaim-policy
   reclaimPolicy: Retain
   # Set to true to allow PVC expansion


### PR DESCRIPTION
https://juicefs.com/docs/csi/guide/pv/#helm-sc

When using storageclass, you can specify an existing secret, which avoids putting credentials directly in value.yaml. At the same time, use helm to manage the configuration of storageclass, so that it can be used in a production environment.