### PR TITLE
Dashboard auth supports using existing secrets

### DIFF
--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver
 type: application
-version: 0.21.2
+version: 0.21.3
 appVersion: 0.25.2
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/juicedata/juicefs-csi-driver

--- a/charts/juicefs-csi-driver/templates/deployment.yaml
+++ b/charts/juicefs-csi-driver/templates/deployment.yaml
@@ -1,4 +1,10 @@
 {{- if and (.Values.dashboard.enabled) }}
+
+{{- $secretName := printf "juicefs-dashboard-secret" -}}
+{{- if .Values.dashboard.auth.existingSecret }}
+{{ $secretName = .Values.dashboard.auth.existingSecret | quote }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,12 +73,12 @@ spec:
             - name: USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: juicefs-dashboard-secret
+                  name: {{ $secretName }}
                   key: username
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: juicefs-dashboard-secret
+                  name: {{ $secretName }}
                   key: password
             {{- end }}
             - name: JUICEFS_CONFIG_NAME

--- a/charts/juicefs-csi-driver/templates/secret.yaml
+++ b/charts/juicefs-csi-driver/templates/secret.yaml
@@ -17,7 +17,7 @@ data:
   tls.key: {{ b64enc (include "webhook.keyPEM" .) }}
 {{- end }}
 {{- end }}
-{{- if and .Values.dashboard.enabled .Values.dashboard.auth.enabled }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.auth.enabled .Values.dashboard.auth.secretEnabled }}
 ---
 kind: Secret
 apiVersion: v1

--- a/charts/juicefs-csi-driver/templates/secret.yaml
+++ b/charts/juicefs-csi-driver/templates/secret.yaml
@@ -17,7 +17,7 @@ data:
   tls.key: {{ b64enc (include "webhook.keyPEM" .) }}
 {{- end }}
 {{- end }}
-{{- if and .Values.dashboard.enabled .Values.dashboard.auth.enabled .Values.dashboard.auth.secretEnabled }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.auth.enabled (not .Values.dashboard.auth.existingSecret) }}
 ---
 kind: Secret
 apiVersion: v1

--- a/charts/juicefs-csi-driver/templates/storageclass.yaml
+++ b/charts/juicefs-csi-driver/templates/storageclass.yaml
@@ -1,7 +1,7 @@
 {{ $namespace := .Release.Namespace | quote }}
 {{- range $_, $sc := .Values.storageClasses }}
 
-{{- if and $sc.enabled $sc.secretEnabled }}
+{{- if and ($sc.enabled) (not $sc.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -49,8 +49,8 @@ data:
 {{- if $sc.enabled }}
 
 {{- $secretName := printf "%s-secret" $sc.name -}}
-{{- if not $sc.secretEnabled }}
-{{ $secretName = $sc.secretName | quote }}
+{{- if $sc.existingSecret }}
+{{ $secretName = $sc.existingSecret | quote }}
 {{- end }}
 
 apiVersion: storage.k8s.io/v1

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -264,6 +264,8 @@ dashboard:
   # Basic auth for dashboard
   auth:
     enabled: false
+    # Set secretEnabled to indicate whether you need to create the secret. If False, you should create a secret called juicefs-dashboard-secret
+    secretEnabled: false
     username: admin
     password: admin
 

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -264,8 +264,8 @@ dashboard:
   # Basic auth for dashboard
   auth:
     enabled: false
-    # Set secretEnabled to indicate whether you need to create the secret. If False, you should create a secret called juicefs-dashboard-secret
-    secretEnabled: false
+    # Set existingSecret to indicate whether to use an existing secret. If it is empty, a corresponding secret will be created according to the plain text configuration.
+    existingSecret: ""
     username: admin
     password: admin
 
@@ -354,10 +354,8 @@ storageClasses:
 - name: "juicefs-sc"
   # Set to true to actually create this StorageClass
   enabled: false
-  # Set secretEnabled to indicate whether you need to create the secret. If False, you can set the existing secret.
-  secretEnabled: true
-  # Must set secretName when secretEnabled is false
-  secretName: juicefs-exist-secret
+  # Set existingSecret to indicate whether to use an existing secret. If it is empty, a corresponding secret will be created according to the plain text configuration.
+  existingSecret: ""
   # Either Retain or Delete, ref: https://juicefs.com/docs/csi/guide/resource-optimization#reclaim-policy
   reclaimPolicy: Retain
   # Set to true to allow PVC expansion


### PR DESCRIPTION
In a production environment, do not write plain text usernames and passwords in the value.yaml. 

ref: https://github.com/juicedata/charts/pull/127
Refer to some open source charts, which generally use the existingSecret configuration implementation, which is easier to understand than secretEnabled, so change it to existingSecret