### PR TITLE
fix: only apply configmap during the first install

### DIFF
--- a/charts/juicefs-csi-driver/templates/configmap.yaml
+++ b/charts/juicefs-csi-driver/templates/configmap.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/component: config
     {{- include "juicefs-csi.labels" . | nindent 4 }}
+{{- if .Release.IsInstall }}
 data:
   config.yaml: |-
     {{- toYaml .Values.globalConfig | nindent 4  }}
+{{- end }}
 {{- end }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -47,6 +47,8 @@ mountMode: mountpod
 
 # This file contains the configuration options for the JuiceFS CSI driver
 # Ref: https://juicefs.com/docs/zh/csi/guide/configurations#configmap
+# NOTE: this config only apply in first install
+# if you want to update it, you need to edit the configmap directly, or use csi-dashboard to update it
 globalConfig:
   # Set to false to disable global config
   enabled: true


### PR DESCRIPTION
Avoid the config being overwritten when upgrading CSI if the config has been updated elsewhere.