### PR TITLE
feat(juicefs-csi-driver): add dataEncryption.enabled (= --format-in-pod=true)

### DIFF
--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver
 type: application
-version: 0.22.6
+version: 0.23.0
 appVersion: 0.26.4
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/juicedata/juicefs-csi-driver

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -63,6 +63,9 @@ spec:
         {{- if eq .Values.mountMode "process" }}
         - --by-process=true
         {{- end }}
+        {{- if .Values.dataEncryption.enabled }}
+        - --format-in-pod=true
+        {{- end }}
         {{- if .Values.globalConfig.enabled }}
         - --config=/etc/config/config.yaml
         {{- end }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -435,3 +435,7 @@ storageClasses:
     image: ""
     # Set annotations for the mount pod
     annotations: {}
+
+# Enables the Data Encryption feature, ref: https://juicefs.com/docs/csi/security/encryption
+dataEncryption:
+  enabled: false


### PR DESCRIPTION
With this feature we support the Data Encryption feature as outlined in the [documentation page "Enable Data Encryption"](https://juicefs.com/docs/csi/security/encryption).  
  
This basically just adds the flag: `--format-in-pod=true` to the  `juicefs-plugin` container in the `juicefs-csi-node` DaemonSet.
