### PR TITLE
Fix network access of juicefs gateway and bump juicefs version

### DIFF
--- a/charts/juicefs-s3-gateway/Chart.yaml
+++ b/charts/juicefs-s3-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: juicefs-s3-gateway
 description: A Helm chart for JuiceFS S3 Gateway
 type: application
-version: 0.11.2
+version: 0.11.3
 appVersion: "1.6.0"
 home: https://github.com/juicedata/juicefs
 sources:

--- a/charts/juicefs-s3-gateway/README.md
+++ b/charts/juicefs-s3-gateway/README.md
@@ -27,7 +27,7 @@ A Helm chart for JuiceFS S3 Gateway
 | hostNetwork | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"juicedata/mount"` |  |
-| image.tag | string | `"ce-v1.1.0"` | Overrides the image tag which defaults to the chart appVersion. For JuiceFS Community Edition, use ce-vx.x.x style tags For JuiceFS Enterprise Edition, use ee-vx.x.x style tags Find the latest built images in our docker image repo: https://hub.docker.com/r/juicedata/mount |
+| image.tag | string | `"ce-v1.2.3"` | Overrides the image tag which defaults to the chart appVersion. For JuiceFS Community Edition, use ce-vx.x.x style tags For JuiceFS Enterprise Edition, use ee-vx.x.x style tags Find the latest built images in our docker image repo: https://hub.docker.com/r/juicedata/mount |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `"nginx"` |  |

--- a/charts/juicefs-s3-gateway/templates/deployment.yaml
+++ b/charts/juicefs-s3-gateway/templates/deployment.yaml
@@ -69,15 +69,11 @@ spec:
             - sh
             - -c
             {{- if .Values.secret.token }}
-            - juicefs gateway ${VOL_NAME} ${NODE_IP}:{{ .Values.port }} {{ .Values.options }} {{ if .Values.secret.encrypt_rsa_key }}--rsa-key /root/encrypt_rsa_key.pem{{ end }}
+            - juicefs gateway ${VOL_NAME} 0.0.0.0:{{ .Values.port }} {{ .Values.options }} {{ if .Values.secret.encrypt_rsa_key }}--rsa-key /root/encrypt_rsa_key.pem{{ end }}
             {{- else }}
-            - juicefs gateway ${METAURL} ${NODE_IP}:{{ .Values.port }} --metrics=${NODE_IP}:{{ .Values.metricsPort }} {{ .Values.options }} {{ if .Values.secret.encrypt_rsa_key }}--rsa-key /root/encrypt_rsa_key.pem{{ end }}
+            - juicefs gateway ${METAURL} 0.0.0.0:{{ .Values.port }} --metrics=0.0.0.0:{{ .Values.metricsPort }} {{ .Values.options }} {{ if .Values.secret.encrypt_rsa_key }}--rsa-key /root/encrypt_rsa_key.pem{{ end }}
             {{- end }}
           env:
-            - name: NODE_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
             {{- if .Values.secret.token }}
             - name: TOKEN
               valueFrom:

--- a/charts/juicefs-s3-gateway/values.yaml
+++ b/charts/juicefs-s3-gateway/values.yaml
@@ -7,7 +7,7 @@ image:
   # For JuiceFS Community Edition, use ce-vx.x.x style tags
   # For JuiceFS Enterprise Edition, use ee-vx.x.x style tags
   # Find the latest built images in our docker image repo: https://hub.docker.com/r/juicedata/mount
-  tag: "ce-v1.1.0"
+  tag: "ce-v1.2.3"
 
 port: 9000
 metricsPort: 9567


### PR DESCRIPTION
Currently network is restricted coming through the node ip which is not the usual way kubernetes services are used/exposed.