### PR TITLE
enhance the juicefs helm charts

### DIFF
--- a/charts/juicefs-csi-driver/templates/deployment.yaml
+++ b/charts/juicefs-csi-driver/templates/deployment.yaml
@@ -22,6 +22,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.dashboard.replicas }}
+  strategy:
+    {{- toYaml .Values.dashboard.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
       app: juicefs-csi-dashboard
@@ -39,6 +41,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.dashboard.hostAliases }}
+      hostAliases: {{ toYaml .Values.dashboard.hostAliases | nindent 6 }}
+      {{- end }}
+      {{- if .Values.dashboard.podSecurityContext }}
+      securityContext: {{ toYaml .Values.dashboard.podSecurityContext | nindent 8 }}
+      {{- end }}    
       serviceAccountName: {{ include "juicefs-csi.dashboard.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -46,6 +54,10 @@ spec:
       {{- end }}
       containers:
         - name: dashboard
+          {{- if .Values.dashboard.securityContext }}
+          securityContext:
+          {{- toYaml .Values.dashboard.securityContext | nindent 12 }}        
+          {{- end }}
           image: {{ .Values.dashboardImage.repository }}:{{ .Values.dashboardImage.tag }}
           {{- if .Values.dashboardImage.pullPolicy }}
           imagePullPolicy: {{ .Values.dashboardImage.pullPolicy }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -204,7 +204,7 @@ controller:
   # Example:
   #  - name: ENABLE_APISERVER_LIST_CACHE
   #    value: "true"
-  envs:
+  envs: []
 
 node:
   # CSI Node Service will be deployed in every node
@@ -328,6 +328,30 @@ dashboard:
     #      - chart-example.local
   priorityClassName: system-node-critical
   envs: []
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 25%
+      
+  # Configure the pod level securityContext.
+  podSecurityContext: {}
+
+  # Configure SecurityContext for Pod.
+  # Ensure that required linux capability to bind port number below 1024 is assigned (`CAP_NET_BIND_SERVICE`).
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  
+  hostAliases: []
+  # - ip: "127.0.0.1"
+  #   hostnames:
+  #   - "foo.local"
+  #   - "bar.local"
 
 # Override mount image, ref: https://juicefs.com/docs/csi/guide/custom-image/
 defaultMountImage:


### PR DESCRIPTION
1. Modified controller.envs to be explicitly defined as an empty array (envs: []), maintaining consistency with similar configurations in node.envs and dashboard.envs.
2. Added updateStrategy configuration for the juicers csi dashboard
3. Security Enhancements for Dashboard by adding pod-level and container-level SecurityContext
4. Added hostAliases configuration option for the dashboard, allowing custom host-to-IP mappings