### PR TITLE
Feature/add extra volume mounts

### DIFF
--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -187,6 +187,9 @@ spec:
         - name: juicefs-config
           mountPath: /etc/config
         {{- end }}
+        {{- with .Values.node.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       - name: node-driver-registrar
         image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
         {{- if .Values.sidecars.nodeDriverRegistrarImage.pullPolicy }}
@@ -303,5 +306,8 @@ spec:
           path: /sys
           type: Directory
         name: host-sys
+      {{- end }}
+      {{- with .Values.node.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -62,7 +62,7 @@ globalConfig:
 
   # Set to true to schedule mount pod to node with via nodeSelector, rather than nodeName
   enableNodeSelector: false
-  
+
   # The mountPodPatch section defines the mount pod spec
   # Each item will be recursively merged into PVC settings according to its pvcSelector
   # If pvcSelector isn't set, the patch will be applied to all PVCs
@@ -74,13 +74,13 @@ globalConfig:
     #     matchLabels:
     #       disable-host-network: "true"
     #   hostNetwork: false
-  
+
     # - pvcSelector:
     #     matchLabels:
     #       apply-labels: "true"
     #   labels:
     #     custom-labels: "asasasa"
-  
+
     # - pvcSelector:
     #     matchLabels:
     #       custom-resources: "true"
@@ -94,7 +94,7 @@ globalConfig:
     #       custom-image: "true"
     #   eeMountImage: "juicedata/mount:ee-5.0.17-0c63dc5"
     #   ceMountImage: "juicedata/mount:ce-v1.2.0"
-  
+
     # - pvcSelector:
     #     matchLabels:
     #       custom-liveness: "true"
@@ -263,6 +263,15 @@ node:
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 3
+  # extraVolumes and extraVolumeMounts can be useful to mount in ca certificates for databases
+  extraVolumes: []
+  #  - name: db-ca
+  #    secret:
+  #      secretName: ca-bundle
+  extraVolumeMounts: []
+  #  - name: db-ca
+  #    mountPath: /db-ca
+  #    readOnly: true
 
 # Expose CSI Driver metrics
 metrics:
@@ -342,7 +351,7 @@ dashboard:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 25%
-      
+
   # Configure the pod level securityContext.
   podSecurityContext: {}
 
@@ -354,7 +363,7 @@ dashboard:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  
+
   hostAliases: []
   # - ip: "127.0.0.1"
   #   hostnames:


### PR DESCRIPTION
Add node.extraVolume and node extraVolumeMounts to csi helm chart. This allows mounting in ca certs to the juicefs-plugin container for metadata configurations that need it.