### PR TITLE
Add option to specify service account for S3 gateway pods and allow env vars to be used for auth with storage backend

### DIFF
--- a/charts/juicefs-s3-gateway/templates/deployment.yaml
+++ b/charts/juicefs-s3-gateway/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       initContainers:
         - name: format
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -33,14 +36,15 @@ spec:
             - sh
             - -c
             {{- if .Values.secret.token }}
-            - juicefs auth ${name} --token=${token} {{ if .Values.secret.bucket }}--bucket=${bucket}{{ end }} --access-key=${accesskey} --secret-key=${secretkey}
+            - juicefs auth ${name} --token=${token} {{ if .Values.secret.bucket }}--bucket=${bucket}{{ end }}{{ if not .Values.secret.useEnvForInit }} --access-key=${accesskey} --secret-key=${secretkey}{{ end }}
             {{- else }}
-            - juicefs format ${metaurl} ${name} --storage=${storage} --bucket=${bucket} --access-key=${accesskey} --secret-key=${secretkey} {{ .Values.formatOptions }}
+            - juicefs format ${metaurl} ${name} --storage=${storage} --bucket=${bucket}{{ if not .Values.secret.useEnvForInit }} --access-key=${accesskey} --secret-key=${secretkey}{{ end }} {{ .Values.formatOptions }}
             {{- end }}
           envFrom:
             - secretRef:
                 name: juicefs-secret
           env:
+            {{- if not .Values.secret.useEnvForInit }}
             - name: accesskey
               valueFrom:
                 secretKeyRef:
@@ -51,6 +55,7 @@ spec:
                 secretKeyRef:
                   name: juicefs-secret
                   key: secret-key
+            {{- end }}
             {{- if .Values.initEnvs }}
 {{ toYaml .Values.initEnvs | indent 12 }}
             {{- end }}

--- a/charts/juicefs-s3-gateway/values.yaml
+++ b/charts/juicefs-s3-gateway/values.yaml
@@ -15,6 +15,11 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # -- The name of the service account to use for the gateway pods.
+  # If not set, no service account will be specified in the pod spec
+  name: ""
+
 podAnnotations: {}
 
 service:
@@ -88,6 +93,12 @@ secret:
   # CE Ref: https://juicefs.com/docs/community/how_to_setup_object_storage
   # EE Ref (see --bucket): https://juicefs.com/docs/cloud/reference/command_reference/#auth
   bucket: ""
+  # -- Use environment credentials for backend authentication in init container.
+  # When true, --access-key and --secret-key will NOT be passed to juicefs auth/format commands,
+  # allowing JuiceFS to discover credentials from environment variables (e.g., AWS_ACCESS_KEY_ID, 
+  # AWS_SECRET_ACCESS_KEY).
+  # MINIO_ROOT_USER and MINIO_ROOT_PASSWORD will still be set from accessKey/secretKey.
+  useEnvForInit: false
   # -- Encryption settings
   # JFS_RSA_PASSPHRASE: xxx
   # encrypt_rsa_key: |


### PR DESCRIPTION
- Add support for specifying a service account in values file. This enables pod identity-based authentication (e.g., EKS Pod Identity).

- Add `secret.useEnvForInit` flag to allow JuiceFS to discover backend storage credentials from environment variables instead of explicit `--access-key` and `--secret-key` flags in `juicefs auth`/`juicefs format` commands. When enabled, JuiceFS can use credentials from environment variables (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) while `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` continue to use `secret.accessKey` and `secret.secretKey` for S3 gateway API authentication. This decouples backend storage authentication from gateway API authentication.